### PR TITLE
resolve build issue with `netcat`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 RUN apt-get upgrade -y && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential default-libmysqlclient-dev git netcat && \
+        build-essential default-libmysqlclient-dev git netcat-traditional && \
     apt-get clean -y
 
 WORKDIR /app


### PR DESCRIPTION
Fixes #19.

Build was failing with error about `netcat`…

```txt
#0 11.09 Package netcat is a virtual package provided by:
#0 11.09   netcat-openbsd 1.219-1
#0 11.09   netcat-traditional 1.10-47
#0 11.09
#0 11.10 E: Package 'netcat' has no installation candidate
------
failed to solve: process "/bin/sh -c apt-get upgrade -y &&     apt-get update &&     apt-get install -y --no-install-recommends         build-essential default-libmysqlclient-dev git netcat &&     apt-get clean -y" did not complete successfully: exit code: 100
```

According to «[https://forums.docker.com/t/package-netcat-has-no-installation-candidate-how-to-fix-this/136541](https://forums.docker.com/t/package-netcat-has-no-installation-candidate-how-to-fix-this/136541)», the solution is to replace installation of `netcat` with `netcat-traditional` instead.

This worked in the local environment.